### PR TITLE
add `verbose` flag

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -12,6 +12,7 @@ import (
 var (
 	profileName string
 	installFlag bool
+	verboseFlag bool
 
 	openCmd = &cobra.Command{
 		Use:   "open [profile_name]",
@@ -27,10 +28,10 @@ var (
 			utils.Check(err)
 
 			if installFlag {
-				code.InstallExtensions(p)
+				code.InstallExtensions(p, verboseFlag)
 			}
 
-			code.LaunchCode(p)
+			code.LaunchCode(p, verboseFlag)
 		},
 	}
 )
@@ -40,6 +41,7 @@ func Execute() {
 	var rootCmd = &cobra.Command{Use: "code-profiles"}
 
 	openCmd.Flags().BoolVarP(&installFlag, "install", "i", false, "should install extensions before opening vscode")
+	openCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "prints additional logs")
 
 	rootCmd.AddCommand(openCmd)
 

--- a/code/code.go
+++ b/code/code.go
@@ -10,29 +10,31 @@ import (
 )
 
 // InstallExtensions install all of profile's extensions and dependencies (DependsOn) to the profile's path.
-func InstallExtensions(profile config.Profile) {
+func InstallExtensions(profile config.Profile, verbose bool) {
 	println("installing extensions for profile '" + profile.Name + "'")
 	cmd_args := []string{".", "--extensions-dir", profile.Path}
 	cmd_args = append(cmd_args, getInstallArgs(profile.Extensions)...)
 
 	if len(profile.DependsOn) > 0 {
 		for i, dep_exts := range profile.DependsOn {
-			fmt.Printf("installing dependency %d/%d for profile '%s'\n", i+1, len(profile.DependsOn), profile.Name)
+			if verbose {
+				fmt.Printf("installing dependency %d/%d for profile '%s'\n", i+1, len(profile.DependsOn), profile.Name)
+			}
 			cmd_args = append(cmd_args, getInstallArgs(dep_exts)...)
 		}
 	}
 
 	cmd_args = append(cmd_args, "--force")
 
-	runCmd(cmd_args)
+	runCmd(cmd_args, verbose)
 }
 
 // LaunchCode takes a profile and launch code loading only extensions in the profile's path
-func LaunchCode(profile config.Profile) {
+func LaunchCode(profile config.Profile, verbose bool) {
 	println("launching code with profile '" + profile.Name + "'")
 	cmd_args := []string{".", "--extensions-dir", profile.Path}
 
-	runCmd(cmd_args)
+	runCmd(cmd_args, verbose)
 }
 
 // getInstallArgs returns an array of command arguments to install extensions in the input array.
@@ -45,10 +47,12 @@ func getInstallArgs(exts []string) []string {
 }
 
 // runCmd runs `code` cli with the given command arguments and prints it's output once finished.
-func runCmd(cmd_args []string) {
+func runCmd(cmd_args []string, verbose bool) {
 	cmd := exec.Command("code", cmd_args...)
 
 	out, err := cmd.CombinedOutput()
-	fmt.Printf("%s", out)
+	if verbose {
+		fmt.Printf("%s", out)
+	}
 	utils.Check(err)
 }


### PR DESCRIPTION
# 📖 Description
Adds a verbose flag to show more logs when required. Default behaviour is non-verbose.

## 📕 References
#3 