### PR TITLE
add `install` command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"code-profiles/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	verboseFlag bool
+	installFlag bool
+)
+
+// Execute runs the main cobra command for cli `code-profiles`.
+func Execute() {
+	var rootCmd = &cobra.Command{Use: "code-profiles"}
+
+	openCmd.Flags().BoolVarP(&installFlag, "install", "i", false, "should install extensions before opening vscode")
+	openCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "prints additional logs")
+
+	installCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "prints additional logs")
+
+	rootCmd.AddCommand(openCmd)
+	rootCmd.AddCommand(installCmd)
+
+	utils.Check(rootCmd.Execute())
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,4 +1,3 @@
-// Package cmd exposes function to interact with the cobra command
 package cmd
 
 import (
@@ -9,9 +8,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var openCmd = &cobra.Command{
-	Use:   "open [profile_name]",
-	Short: "open VSCode using a custom profile for extensions",
+var installCmd = &cobra.Command{
+	Use:   "install [profile_name]",
+	Short: "install required VSCode extensions for a given profile",
 	Run: func(cmd *cobra.Command, args []string) {
 		var p config.Profile
 		var err error
@@ -22,10 +21,6 @@ var openCmd = &cobra.Command{
 		}
 		utils.Check(err)
 
-		if installFlag {
-			code.InstallExtensions(p, verboseFlag)
-		}
-
-		code.LaunchCode(p, verboseFlag)
+		code.InstallExtensions(p, verboseFlag)
 	},
 }


### PR DESCRIPTION
# 📖 Description
Add a standalone command `install` to... well install VS Code extensions in the Profile's path.