### PR TITLE
Fix profile paths not working

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -50,7 +50,7 @@ profiles:
 			baseProfileBody,
 			"base",
 
-			&Profile{Name: "base", ProfilePath: "./base", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base", ExtsPath: "./base", Extensions: []string{"some.very.real.ext.id"}},
 			false,
 			false,
 		},
@@ -59,7 +59,7 @@ profiles:
 			multipleProfilesBody,
 			"base2",
 
-			&Profile{Name: "base2", ProfilePath: "./base2", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base2", ExtsPath: "./base2", Extensions: []string{"some.very.real.ext.id"}},
 			false,
 			false,
 		},
@@ -117,7 +117,7 @@ func Test_GetProfile(t *testing.T) {
 			false,
 			"base",
 
-			&Profile{Name: "base", ProfilePath: "./base", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base", ExtsPath: "./base", Extensions: []string{"some.very.real.ext.id"}},
 			nil,
 		},
 		{
@@ -127,7 +127,7 @@ func Test_GetProfile(t *testing.T) {
 			false,
 			"base",
 
-			&Profile{Name: "base", ProfilePath: "./base", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base", ExtsPath: "./base", Extensions: []string{"some.very.real.ext.id"}},
 			nil,
 		},
 		{
@@ -137,7 +137,7 @@ func Test_GetProfile(t *testing.T) {
 			false,
 			"",
 
-			&Profile{Name: "base", ProfilePath: "./base", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base", ExtsPath: "./base", Extensions: []string{"some.very.real.ext.id"}},
 			nil,
 		},
 		{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,16 +13,19 @@ var (
 	baseProfileBody = `
 profiles:
   - name: base
+    profile-path: ./base
     extensions:
       - some.very.real.ext.id
 `
 	multipleProfilesBody = `
 profiles:
   - name: base
+    profile-path: ./base
     extensions:
       - some.very.real.ext.id
 
   - name: base2
+    profile-path: ./base2
     extensions:
       - some.very.real.ext.id
 `
@@ -33,7 +36,7 @@ profiles:
 	extensions:
 `
 
-	testRuns = []struct {
+	sharedTestRuns = []struct {
 		testName           string
 		initialDiskData    string
 		profileNameToFetch string
@@ -47,7 +50,7 @@ profiles:
 			baseProfileBody,
 			"base",
 
-			&Profile{Name: "base", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base", ProfilePath: "./base", Extensions: []string{"some.very.real.ext.id"}},
 			false,
 			false,
 		},
@@ -56,7 +59,7 @@ profiles:
 			multipleProfilesBody,
 			"base2",
 
-			&Profile{Name: "base2", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base2", ProfilePath: "./base2", Extensions: []string{"some.very.real.ext.id"}},
 			false,
 			false,
 		},
@@ -114,7 +117,7 @@ func Test_GetProfile(t *testing.T) {
 			false,
 			"base",
 
-			&Profile{Name: "base", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base", ProfilePath: "./base", Extensions: []string{"some.very.real.ext.id"}},
 			nil,
 		},
 		{
@@ -124,7 +127,7 @@ func Test_GetProfile(t *testing.T) {
 			false,
 			"base",
 
-			&Profile{Name: "base", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base", ProfilePath: "./base", Extensions: []string{"some.very.real.ext.id"}},
 			nil,
 		},
 		{
@@ -134,7 +137,7 @@ func Test_GetProfile(t *testing.T) {
 			false,
 			"",
 
-			&Profile{Name: "base", Extensions: []string{"some.very.real.ext.id"}},
+			&Profile{Name: "base", ProfilePath: "./base", Extensions: []string{"some.very.real.ext.id"}},
 			nil,
 		},
 		{
@@ -205,7 +208,6 @@ func Test_GetProfile(t *testing.T) {
 }
 
 func Test_SetConfigPath(t *testing.T) {
-	_configPath = "./code-profiles.yml"
 	t.Run("initial config name is set corretly", func(t *testing.T) {
 		assert.Equal(t, "./code-profiles.yml", _configPath)
 	})
@@ -221,6 +223,8 @@ func Test_SetConfigPath(t *testing.T) {
 	t.Run("setting the config path to an empty value doesn't do anything", func(t *testing.T) {
 		assert.Nil(t, _instance)
 		instance()
+		assert.NotNil(t, _instance)
+
 		SetConfigPath("")
 		assert.NotNil(t, _instance)
 		assert.Equal(t, "./code-profiles.yml", _configPath)
@@ -228,7 +232,7 @@ func Test_SetConfigPath(t *testing.T) {
 }
 
 func Test_getProfileByName(t *testing.T) {
-	for _, tr := range testRuns {
+	for _, tr := range sharedTestRuns {
 		t.Run(tr.testName, func(t *testing.T) {
 			os.Remove("code-profiles.yml")
 			_configPath = "./code-profiles.yml"
@@ -255,7 +259,7 @@ func Test_getProfileByName(t *testing.T) {
 }
 
 func Test_getProfileFromFile(t *testing.T) {
-	for _, tr := range testRuns {
+	for _, tr := range sharedTestRuns {
 		t.Run(tr.testName, func(t *testing.T) {
 			os.Remove("code-profiles.yml")
 			os.ReadDir(".code-profile")

--- a/config/profile.go
+++ b/config/profile.go
@@ -9,15 +9,15 @@ import (
 )
 
 type Profile struct {
-	Name        string     `yaml:"name"`
-	Extensions  []string   `yaml:"extensions,flow"`
-	DependsOn   [][]string `yaml:"depends-on,flow"`
-	ProfilePath string     `yaml:"profile-path"`
+	Name       string     `yaml:"name"`
+	Extensions []string   `yaml:"extensions,flow"`
+	DependsOn  [][]string `yaml:"depends-on,flow"`
+	ExtsPath   string     `yaml:"profile-path"`
 }
 
 // Path returns the absolute path of the profile.
 func (p Profile) Path() string {
-	return fileutil.ReplaceTilde(p.ProfilePath)
+	return fileutil.ReplaceTilde(p.ExtsPath)
 }
 
 // GetProfile returns either the named profile or loads the .code-profile value & tries to return this profile.

--- a/config/profile.go
+++ b/config/profile.go
@@ -9,15 +9,15 @@ import (
 )
 
 type Profile struct {
-	Name       string     `yaml:"name"`
-	Extensions []string   `yaml:"extensions,flow"`
-	DependsOn  [][]string `yaml:"depends-on,flow"`
-	path       string     `yaml:"profile-path"`
+	Name        string     `yaml:"name"`
+	Extensions  []string   `yaml:"extensions,flow"`
+	DependsOn   [][]string `yaml:"depends-on,flow"`
+	ProfilePath string     `yaml:"profile-path"`
 }
 
 // Path returns the absolute path of the profile.
 func (p Profile) Path() string {
-	return fileutil.ReplaceTilde(p.path)
+	return fileutil.ReplaceTilde(p.ProfilePath)
 }
 
 // GetProfile returns either the named profile or loads the .code-profile value & tries to return this profile.

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"code-profiles/utils"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Path(t *testing.T) {
+	runs := []struct {
+		testName     string
+		givenProfile Profile
+		expectedPath string
+	}{
+		{
+			"with simple profile path",
+			Profile{ProfilePath: "./test"},
+			"./test",
+		},
+		{
+			"with simple path starting with ~",
+			Profile{ProfilePath: "~"},
+			"home_dir",
+		},
+		{
+			"with more complex path starting with ~",
+			Profile{ProfilePath: "~/some-dir"},
+			"home_dir/some-dir",
+		},
+		{
+			"with path containing a ~",
+			Profile{ProfilePath: "./~"},
+			"./~",
+		},
+	}
+
+	for _, r := range runs {
+		t.Run(r.testName, func(tt *testing.T) {
+			homeDir, err := os.UserHomeDir()
+			utils.Check(err)
+
+			expectedPath := strings.Replace(r.expectedPath, "home_dir", homeDir, 1)
+
+			assert.Equal(tt, expectedPath, r.givenProfile.Path())
+		})
+	}
+}

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -17,22 +17,22 @@ func Test_Path(t *testing.T) {
 	}{
 		{
 			"with simple profile path",
-			Profile{ProfilePath: "./test"},
+			Profile{ExtsPath: "./test"},
 			"./test",
 		},
 		{
 			"with simple path starting with ~",
-			Profile{ProfilePath: "~"},
+			Profile{ExtsPath: "~"},
 			"home_dir",
 		},
 		{
 			"with more complex path starting with ~",
-			Profile{ProfilePath: "~/some-dir"},
+			Profile{ExtsPath: "~/some-dir"},
 			"home_dir/some-dir",
 		},
 		{
 			"with path containing a ~",
-			Profile{ProfilePath: "./~"},
+			Profile{ExtsPath: "./~"},
 			"./~",
 		},
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,13 +1,10 @@
 package utils
 
-import "os"
-
 // package utils exposes various useful functions. well, function in that case...
 
 // Check panics if error is not nil.
 func Check(e error) {
 	if e != nil {
-		println(e.Error())
-		os.Exit(0)
+		panic(e.Error())
 	}
 }


### PR DESCRIPTION
# 📖 Description
Expose the `ExtsPath` field to `reflect` so it can unmarshal `profile-path` correctly from YAML.

### Notes 📓 
`profile-path` should be renamed in the YAML and it will be done in #26 

### References 🔗
Fixes: #25