### PR TITLE
DevOps - Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release-code-profiles:
+    name: release code-profiles
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [darwin, linux]
+        goarch: [arm, arm64, amd64]
+    
+    steps:
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.36
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goversion: 1.18
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,64 @@
-# 🖥 code-profiles 💻
+# code-profiles 💻
 
 [![CI](https://github.com/marcantoineg/code-profiles/actions/workflows/ci.yml/badge.svg)](https://github.com/marcantoineg/code-profiles/actions/workflows/ci.yml)
 <img height="20px" src="https://img.shields.io/badge/Golang-FFFFFF?logo=go&style=flat">
 
+## Simply, what is it?
 Profiles for VS Code Extensions.
 
-I plan to use this to open only the extensions I need in VS Code depending on projects.
+I use this to load only the extensions I need in VS Code depending on projects.
 
+
+## How does it work?
 You need 2 things:
 - a `code-profiles.yml` where your executable is. This is where you define your profiles.
-- a `.code-profile` with a valid profile id/name. This will start code using `--extensions-dir` with the right extensions.
+- a `.code-profile` with a valid profile name. This will start VSCode using `--extensions-dir` with the right extensions.
 
 You have multiple commands:
-- `open`: which opens code with a profile.
-<br>_From file in cwd (`.code-profile`) or args (`open` vs `open some-profile`)_
-- `install`: which installs required extensions for the profile.
-<br>_From file in cwd (`.code-profile`) or args (`install` vs `install some-profile`)_
-- `profile add [name]`: create config and/or appends to config a blank profile
+- `open`: which opens VSCode with a specified profile.
+<br>_From the `.code-profile` file in the current working directory or args (`code-profiles open [profile_name]`)_
+- `install`: which installs required extensions for a specified profile.
+<br>_From the `.code-profile` file in the CWD or args (`code-profiles install [profile_name]`)_
+
+## Usage
+Basic commands:
+```
+Usage:
+  code-profiles [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  install     install required VSCode extensions for a given profile
+  open        open VSCode using a custom profile for extensions
+
+Flags:
+  -h, --help   help for code-profiles
+```
+
+### install
+```
+install required VSCode extensions for a given profile
+
+Usage:
+  code-profiles install [profile_name] [flags]
+
+Flags:
+  -c, --config-path string   Path to code-profiles config (default "./code-profiles.yml")
+  -h, --help                 help for install
+  -v, --verbose              prints additional logs
+```
+
+### open
+```
+open VSCode using a custom profile for extensions
+
+Usage:
+  code-profiles open [profile_name] [flags]
+
+Flags:
+  -c, --config-path string   Path to code-profiles config (default "./code-profiles.yml")
+  -h, --help                 help for open
+  -i, --install              should install extensions before opening VSCode
+  -v, --verbose              prints additional logs
+```

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -18,7 +18,7 @@ func Execute() {
 	var rootCmd = &cobra.Command{Use: "code-profiles"}
 
 	openCmd.Flags().StringVarP(&configPathFlag, "config-path", "c", "./code-profiles.yml", "Path to code-profiles config")
-	openCmd.Flags().BoolVarP(&installFlag, "install", "i", false, "should install extensions before opening vscode")
+	openCmd.Flags().BoolVarP(&installFlag, "install", "i", false, "should install extensions before opening VSCode")
 	openCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "prints additional logs")
 
 	installCmd.Flags().StringVarP(&configPathFlag, "config-path", "c", "./code-profiles.yml", "Path to code-profiles config")


### PR DESCRIPTION
# 📖 Description
Adds a simple release flow for `code-profiles`.

Everytime a release is created on github, the workflow will upload binaries for `darwin` and `linux` for the following archs:
- `arm`
- `arm64`
- `amd64`

## References 🔗
Resolves #15 